### PR TITLE
Switch from netstat to route to get network interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,26 +12,27 @@ MKDIR=/bin/mkdir
 SED=/usr/bin/sed
 AWK=/usr/bin/awk
 INSTALL=/usr/bin/install
-NETSTAT=/usr/bin/netstat
+ROUTE=/sbin/route
 GREP=/usr/bin/grep
 GIT=${LOCALBASE}/bin/git
 
-.if !defined{VERSION}
-VERSION!=	${GIT} describe --tags --always
+.if !defined(VERSION)
+VERSION!= ${GIT} describe --tags --always
 .endif
 
-SUB_LIST=	PREFIX=${PREFIX} \
-		LOCALBASE=${LOCALBASE} \
-		VERSION=${VERSION} \
-		GUEST_ROOT=${GUEST_ROOT}
+SUB_LIST= PREFIX=${PREFIX} \
+          LOCALBASE=${LOCALBASE} \
+          VERSION=${VERSION} \
+          GUEST_ROOT=${GUEST_ROOT}
 
-GATE!=		${NETSTAT} -nr | ${GREP} default | ${AWK} '{ print $$4 }'
-.if ${GATE} == ""
+# Use route to get the IPv4 default interface
+GATE!= ${ROUTE} -n get -inet default | ${GREP} 'interface:' | ${AWK} '{ print $$2 }'
+.if empty(GATE)
 GATE=ue0
 .endif
-SUB_LIST+=	EXT_IF=${GATE}
+SUB_LIST+= EXT_IF=${GATE}
 
-_SUB_LIST_EXP= 	${SUB_LIST:S/$/!g/:S/^/ -e s!%%/:S/=/%%!/}
+_SUB_LIST_EXP= ${SUB_LIST:S/$/!g/:S/^/ -e s!%%/:S/=/%%!/}
 
 install:
 	${MKDIR} -p ${BINDIR}
@@ -51,4 +52,4 @@ install:
 
 .PHONY: clean
 
-clean: ; 
+clean: ;


### PR DESCRIPTION
Hi,

I noticed that `netstat -nr | grep default | awk '{ print $4 }'` returns multiple lines on my system by grabbing the default routes from the separate IPv4 and IPv6 routing tables, which broke the installation script for me. I replaced it with `route -n get -inet default | grep 'interface:' | awk '{ print $2 }'` which returns the interface of the default route from the IPv4 routing table and this resolved the issue.